### PR TITLE
Patch for fhc(3) on Solaris 10 and earlier.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ AC_FUNC_FORK
 AC_FUNC_LSTAT_FOLLOWS_SLASHED_SYMLINK
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
-AC_CHECK_FUNCS([bzero fchdir getcwd memmove memset strchr strerror strrchr strtol])
+AC_CHECK_FUNCS([bzero dirfd fchdir getcwd memmove memset strchr strerror strrchr strtol])
 
 # OS detection
 AC_CANONICAL_HOST

--- a/src/fts.h
+++ b/src/fts.h
@@ -37,10 +37,13 @@
 #define MAX(a, b) ((a) >= (b) ? (a) : (b))
 
 #if defined(__sun) || defined(__sun__)
-/* IllumOS provides dirfd() , see /usr/include/dirent.h */
-#if !(defined(__EXTENSIONS__) || !defined(__XOPEN_OR_POSIX) || \
-        defined(_ATFILE_SOURCE))
-#define dirfd(X) ((X)->d_fd)
+/* Solaris 10 and Earlier */
+#if !defined(HAVE_DIRFD) && !defined(__XOPEN_OR_POSIX)
+#define dirfd(X) ((X)->dd_fd) /* traditional SVR4 */
+#else
+/* Solaris 11 and later */
+#if !defined(HAVE_DIRFD) && defined(__XOPEN_OR_POSIX)
+#define dirfd(X) ((X)->d_fd) /* POSIX conformant */
 #endif
 #endif
 #endif

--- a/src/fts.h
+++ b/src/fts.h
@@ -36,6 +36,7 @@
 #if !defined(__FreeBSD__) && !defined(__linux__)
 #define MAX(a, b) ((a) >= (b) ? (a) : (b))
 
+/* IllumOS provides dirfd() , see /usr/include/dirent.h */
 #if defined(__sun) || defined(__sun__)
 /* Solaris 10 and Earlier */
 #if !defined(HAVE_DIRFD) && !defined(__XOPEN_OR_POSIX)

--- a/src/fts.h
+++ b/src/fts.h
@@ -47,6 +47,7 @@
 #endif
 #endif
 #endif
+#endif
 
 #if defined(__FreeBSD__)
 #include <sys/_types.h>


### PR DESCRIPTION
As Solaris 10 and earlier require the traditional SVR4 `dd_fd` mapping and Solaris 11 needs the post-POSIX.1-2008 `d_fd` mapping due to a lack of support for `dirfd`.

_Note: I left in verbose comments as this is harder to test these days and this seems to be an external Patch._

## Steps to reproduce

On Solaris 10
```
autoreconf -i
./configure
gmake
....
Undefined                       first referenced
 symbol                             in file
dirfd                               fpart-fts.o
ld: fatal: symbol referencing errors. No output written to fpart
gmake[1]: *** [Makefile:363: fpart] Error 2
```

Various OS `./configure` output, all tests from the docs except for the [grep '^0:' ](https://github.com/martymac/fpart/blob/master/README#L83)which needs a wild card  with the file size field tested fine on Solaris 10, 11, OI hipster, Ubuntu and MacOS.

### Ubuntu 18.04 LTS
```  
checking for dirfd... yes
checking for fchdir... yes
```
### SunOS openindiana 5.11 illumos-d9241f9954 i86pc i386 i86p
```
checking for dirfd... yes
checking for fchdir... yes
```
### Solaris 10
```
checking for dirfd... no
checking for fchdir... yes
```