### PR TITLE
Document RPM build and update to 1.2.0

### DIFF
--- a/contribs/package/rpm/README
+++ b/contribs/package/rpm/README
@@ -1,0 +1,11 @@
+To build RPM packages:
+
+wget https://github.com/martymac/fpart/archive/master.tar.gz
+tar xvfz master.tar.gz
+rm master.tar.gz
+version=$(awk '/^Version/ { print $2 }' fpart-master/contribs/package/rpm/fpart.spec)
+mv fpart-master fpart-${version}
+tar cvfz ~/rpmbuild/SOURCES/fpart-${version}.tar.gz fpart-${version}
+cp fpart-${version}/contribs/package/rpm/fpart.spec ~/rpmbuild/SPECS/
+cd ~/rpmbuild/SPECS
+rpmbuild -ba fpart.spec

--- a/contribs/package/rpm/fpart.spec
+++ b/contribs/package/rpm/fpart.spec
@@ -1,6 +1,6 @@
 Name:    fpart
-Version: 1.1.0
-Release: 2%{?dist}
+Version: 1.2.0
+Release: 1%{?dist}
 License: BSD
 Summary: a tool that sorts files and packs them into bags
 URL:     http://contribs.martymac.org
@@ -22,7 +22,7 @@ files. It can also produce partitions with a given number of files or a limited
 size.
 
 %prep
-%setup -q -n %{name}-%{name}-%{version}
+%setup -q -n %{name}-%{version}
 
 %build
 autoreconf --install
@@ -41,6 +41,11 @@ make %{?_smp_mflags}
 %{_bindir}/fpsync
 
 %changelog
+* Tue Oct 29 2019 Christopher Voltz <christopher.voltz@hpe.com> - 1.2.0-1
+- Version 1.2.0
+- Added instructions for building RPMs
+- Fixed build directory name
+
 * Mon Nov 19 2018 Sam P <survient@fedoraproject.org> - 1.1.0-2
 - cleaned up prep and build sections
 - trued up changelog entries


### PR DESCRIPTION
* Add document which shows how to build an RPM from the latest source in the GitHub repo.
* Fix build directory name in `.spec` file and update to version 1.2.0.