### PR TITLE
Spec file cleanup and updates

### DIFF
--- a/contribs/package/README-rpm.txt
+++ b/contribs/package/README-rpm.txt
@@ -1,11 +1,8 @@
 To build RPM packages:
 
-wget https://github.com/martymac/fpart/archive/master.tar.gz
-tar xvfz master.tar.gz
-rm master.tar.gz
-version=$(awk '/^Version/ { print $2 }' fpart-master/contribs/package/rpm/fpart.spec)
-mv fpart-master fpart-${version}
-tar cvfz ~/rpmbuild/SOURCES/fpart-${version}.tar.gz fpart-${version}
-cp fpart-${version}/contribs/package/rpm/fpart.spec ~/rpmbuild/SPECS/
-cd ~/rpmbuild/SPECS
-rpmbuild -ba fpart.spec
+git clone https://github.com/martymac/fpart.git
+cp -f fpart/contribs/package/rpm/fpart.spec rpmbuild/SPECS/
+spectool -g -R rpmbuild/SPECS/fpart.spec
+rpmbuild -ba rpmbuild/SPECS/fpart.spec
+
+Packages are available in Fedora and EPEL repositories

--- a/contribs/package/rpm/fpart.spec
+++ b/contribs/package/rpm/fpart.spec
@@ -1,6 +1,6 @@
 Name:    fpart
 Version: 1.2.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: BSD
 Summary: a tool that sorts files and packs them into bags
 URL:     http://contribs.martymac.org
@@ -22,7 +22,8 @@ files. It can also produce partitions with a given number of files or a limited
 size.
 
 %prep
-%setup -q -n %{name}-%{version}
+# The name macro is used twice due to the way the upstream project includes the project name in its release tags
+%setup -q -n %{name}-%{name}-%{version}
 
 %build
 autoreconf --install
@@ -41,10 +42,18 @@ make %{?_smp_mflags}
 %{_bindir}/fpsync
 
 %changelog
+* Fri Dec 06 2019 Sam P <survient@fedoraproject.org> - 1.2.0-2
+- Revised rpmbuild instructions
+- Added comment about git release tag naming
+- Added mass Fedora 31 rebuild commit history entry
+
 * Tue Oct 29 2019 Christopher Voltz <christopher.voltz@hpe.com> - 1.2.0-1
 - Version 1.2.0
 - Added instructions for building RPMs
 - Fixed build directory name
+
+* Thu Jul 25 2019 Fedora Release Engineering <releng@fedoraproject.org> - 1.1.0-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_31_Mass_Rebuild
 
 * Mon Nov 19 2018 Sam P <survient@fedoraproject.org> - 1.1.0-2
 - cleaned up prep and build sections


### PR DESCRIPTION
Revised rpmbuild instructions.
Added comment in spec file about git release tag naming.
Added mass Fedora 31 rebuild commit history entry.

* The reason why the %{name} macro is used twice in the spec file is due to the fact that this git repository includes the project name in release tags which is not that common. If the next series of release tags were simply named with just the version number(1.2.0) then this could get cleaned up in the spec file. 
* This build process will not work as-is until there is a 1.2.0 release tagged. Normally it would be better to do a release *then* update the spec file but since the spec file is already at 1.2.0 it would be much uglier if not impossible to revert the spec file to the 1.1.0 version, just food for thought for 1.3.0.