### PR TITLE
fpsync: Fix `tool_get_fpart_mode_opts` so that we can pass `-E` to `fpart`

### DIFF
--- a/tools/fpsync
+++ b/tools/fpsync
@@ -303,7 +303,7 @@ tool_get_fpart_mode_opts () {
         "rsync")
 	        # We do *not* want fpart option -zz in dirs-only mode because
 	        # un-readable directories will be created when sync'ing the parent.
-	        echo "-E"
+	        printf "%s\n" "-E"
             ;;
         *)
             ;;


### PR DESCRIPTION
When "Directory mode", `fpsync` will pass `-E` to `fpart` but actually does not. This is caused by the behavior of `echo`: `-E` is treated as an option for `echo` itself. This PR fixes the issue.

```bash
$ echo "-E"

$
```