### PR TITLE
Handle temporary readdir errors

### DIFF
--- a/readdir_error_tests.txt
+++ b/readdir_error_tests.txt
@@ -1,0 +1,263 @@
+==============================
+amir73il/readdir_error branch (including your merge and fixups):
+==============================
+
+--------------------
+No errors injection:
+--------------------
+
+13 dirs in 7 parts
+
+--------------------
+$ ./src/fpart -L -E -Z -f 2 -vv /mnt/nfs/a
+Examining filesystem...
+1 (0): /mnt/nfs/a/b/c/d/e/f/g/h/i/j
+/mnt/nfs/a/b/c/d/e/f/g/h/i/j
+1 (0): /mnt/nfs/a/b/c/d/e/f/g/h/i
+/mnt/nfs/a/b/c/d/e/f/g/h/i
+Filled part #1: size = 0, 2 file(s)
+2 (0): /mnt/nfs/a/b/c/d/e/f/g/h
+/mnt/nfs/a/b/c/d/e/f/g/h
+2 (0): /mnt/nfs/a/b/c/d/e/f/g
+/mnt/nfs/a/b/c/d/e/f/g
+Filled part #2: size = 0, 2 file(s)
+3 (0): /mnt/nfs/a/b/c/d/e/f
+/mnt/nfs/a/b/c/d/e/f
+3 (0): /mnt/nfs/a/b/c/d/e
+/mnt/nfs/a/b/c/d/e
+Filled part #3: size = 0, 2 file(s)
+4 (28): /mnt/nfs/a/b/c/d
+/mnt/nfs/a/b/c/d
+4 (0): /mnt/nfs/a/b/c
+/mnt/nfs/a/b/c
+Filled part #4: size = 28, 2 file(s)
+5 (0): /mnt/nfs/a/b
+/mnt/nfs/a/b
+5 (0): /mnt/nfs/a/amir/subdir
+/mnt/nfs/a/amir/subdir
+Filled part #5: size = 0, 2 file(s)
+6 (10650): /mnt/nfs/a/amir/dir
+/mnt/nfs/a/amir/dir
+6 (0): /mnt/nfs/a/amir
+/mnt/nfs/a/amir
+Filled part #6: size = 10650, 2 file(s)
+7 (12): /mnt/nfs/a
+/mnt/nfs/a
+Filled part #7: size = 12, 1 file(s)
+13 file(s) found.
+
+
+---------------------------------
+Errors injection at odd #readdir:
+---------------------------------
+
+6 dirs in 4 parts, because some subdirs are missed.
+missed subtrees (e.g. a/b/c) will be synced with recursive rsync.
+
+--------------------
+sudo ./fanotify_example /mnt/nfs/ 5
+
+$ ./src/fpart -L -E -Z -f 2 -vv /mnt/nfs/a
+Examining filesystem...
+/mnt/nfs/a/b/c: Operation not permitted
+1 (18446744073709551615): /mnt/nfs/a/b/c
+/mnt/nfs/a/b/c
+Filled part #1: size = 18446744073709551615, 1 file(s)
+2 (0): /mnt/nfs/a/b
+/mnt/nfs/a/b
+2 (0): /mnt/nfs/a/amir/subdir
+/mnt/nfs/a/amir/subdir
+Filled part #2: size = 0, 2 file(s)
+/mnt/nfs/a/amir/dir: Operation not permitted
+3 (18446744073709551615): /mnt/nfs/a/amir/dir
+/mnt/nfs/a/amir/dir
+Filled part #3: size = 18446744073709551615, 1 file(s)
+4 (0): /mnt/nfs/a/amir
+/mnt/nfs/a/amir
+4 (12): /mnt/nfs/a
+/mnt/nfs/a
+Filled part #4: size = 12, 2 file(s)
+6 file(s) found.
+
+
+----------------------------------
+Errors injection at even #readdir:
+----------------------------------
+
+13 dirs in 10 parts, because of separate parts
+All subdirs observed because error is never on first readdir
+
+--------------------
+sudo ./fanotify_example /mnt/nfs/ 6
+
+$ ./src/fpart -L -E -Z -f 2 -vv /mnt/nfs/a
+Examining filesystem...
+1 (0): /mnt/nfs/a/b/c/d/e/f/g/h/i/j
+/mnt/nfs/a/b/c/d/e/f/g/h/i/j
+/mnt/nfs/a/b/c/d/e/f/g/h/i: Operation not permitted
+Filled part #1: size = 0, 1 file(s)
+2 (18446744073709551615): /mnt/nfs/a/b/c/d/e/f/g/h/i
+/mnt/nfs/a/b/c/d/e/f/g/h/i
+Filled part #2: size = 18446744073709551615, 1 file(s)
+3 (0): /mnt/nfs/a/b/c/d/e/f/g/h
+/mnt/nfs/a/b/c/d/e/f/g/h
+3 (0): /mnt/nfs/a/b/c/d/e/f/g
+/mnt/nfs/a/b/c/d/e/f/g
+Filled part #3: size = 0, 2 file(s)
+/mnt/nfs/a/b/c/d/e/f: Operation not permitted
+4 (18446744073709551615): /mnt/nfs/a/b/c/d/e/f
+/mnt/nfs/a/b/c/d/e/f
+Filled part #4: size = 18446744073709551615, 1 file(s)
+5 (0): /mnt/nfs/a/b/c/d/e
+/mnt/nfs/a/b/c/d/e
+5 (28): /mnt/nfs/a/b/c/d
+/mnt/nfs/a/b/c/d
+Filled part #5: size = 28, 2 file(s)
+/mnt/nfs/a/b/c: Operation not permitted
+6 (18446744073709551615): /mnt/nfs/a/b/c
+/mnt/nfs/a/b/c
+Filled part #6: size = 18446744073709551615, 1 file(s)
+7 (0): /mnt/nfs/a/b
+/mnt/nfs/a/b
+/mnt/nfs/a/amir/subdir: Operation not permitted
+Filled part #7: size = 0, 1 file(s)
+8 (18446744073709551615): /mnt/nfs/a/amir/subdir
+/mnt/nfs/a/amir/subdir
+Filled part #8: size = 18446744073709551615, 1 file(s)
+9 (10650): /mnt/nfs/a/amir/dir
+/mnt/nfs/a/amir/dir
+9 (0): /mnt/nfs/a/amir
+/mnt/nfs/a/amir
+Filled part #9: size = 10650, 2 file(s)
+10 (12): /mnt/nfs/a
+/mnt/nfs/a
+Filled part #10: size = 12, 1 file(s)
+13 file(s) found.
+
+
+==============================
+amir73il-readdir_error branch (including all your code changes):
+==============================
+
+--------------------
+No errors injection:
+--------------------
+
+13 dirs in 7 parts
+
+--------------------
+$ ./src/fpart -L -E -zz -Z -f 2 -vv /mnt/nfs/a
+Examining filesystem...
+1 (0): /mnt/nfs/a/b/c/d/e/f/g/h/i/j
+/mnt/nfs/a/b/c/d/e/f/g/h/i/j
+1 (0): /mnt/nfs/a/b/c/d/e/f/g/h/i
+/mnt/nfs/a/b/c/d/e/f/g/h/i
+Filled part #1: size = 0, 2 file(s), errno = 0
+2 (0): /mnt/nfs/a/b/c/d/e/f/g/h
+/mnt/nfs/a/b/c/d/e/f/g/h
+2 (0): /mnt/nfs/a/b/c/d/e/f/g
+/mnt/nfs/a/b/c/d/e/f/g
+Filled part #2: size = 0, 2 file(s), errno = 0
+3 (0): /mnt/nfs/a/b/c/d/e/f
+/mnt/nfs/a/b/c/d/e/f
+3 (0): /mnt/nfs/a/b/c/d/e
+/mnt/nfs/a/b/c/d/e
+Filled part #3: size = 0, 2 file(s), errno = 0
+4 (28): /mnt/nfs/a/b/c/d
+/mnt/nfs/a/b/c/d
+4 (0): /mnt/nfs/a/b/c
+/mnt/nfs/a/b/c
+Filled part #4: size = 28, 2 file(s), errno = 0
+5 (0): /mnt/nfs/a/b
+/mnt/nfs/a/b
+5 (0): /mnt/nfs/a/amir/subdir
+/mnt/nfs/a/amir/subdir
+Filled part #5: size = 0, 2 file(s), errno = 0
+6 (10650): /mnt/nfs/a/amir/dir
+/mnt/nfs/a/amir/dir
+6 (0): /mnt/nfs/a/amir
+/mnt/nfs/a/amir
+Filled part #6: size = 10650, 2 file(s), errno = 0
+7 (12): /mnt/nfs/a
+/mnt/nfs/a
+Filled part #7: size = 12, 1 file(s)
+13 file(s) found.
+
+
+---------------------------------
+Errors injection at odd #readdir:
+---------------------------------
+
+6 dirs in 4 parts, because some subdirs are missed.
+missed subtrees (e.g. a/b/c) will be synced with recursive rsync.
+
+--------------------
+sudo ./fanotify_example /mnt/nfs/ 6
+
+
+$ ./src/fpart -L -E -zz -Z -f 2 -vv /mnt/nfs/a
+Examining filesystem...
+/mnt/nfs/a/b/c: Operation not permitted
+1 (0): /mnt/nfs/a/b/c
+/mnt/nfs/a/b/c
+Filled part #1: size = 0, 1 file(s), errno = 1
+2 (0): /mnt/nfs/a/b
+/mnt/nfs/a/b
+2 (0): /mnt/nfs/a/amir/subdir
+/mnt/nfs/a/amir/subdir
+Filled part #2: size = 0, 2 file(s), errno = 0
+/mnt/nfs/a/amir/dir: Operation not permitted
+3 (0): /mnt/nfs/a/amir/dir
+/mnt/nfs/a/amir/dir
+Filled part #3: size = 0, 1 file(s), errno = 1
+4 (0): /mnt/nfs/a/amir
+/mnt/nfs/a/amir
+4 (12): /mnt/nfs/a
+/mnt/nfs/a
+Filled part #4: size = 12, 2 file(s), errno = 0
+6 file(s) found.
+
+
+----------------------------------
+Errors injection at even #readdir:
+----------------------------------
+
+9 dirs in 5 parts, because dirs with errors are not packed.
+All subdirs have been observed because error is never on first readdir,
+but 4 dirs will not be synced.
+
+--------------------
+sudo ./fanotify_example /mnt/nfs/ 6
+
+$ ./src/fpart -L -E -zz -Z -f 2 -vv /mnt/nfs/a
+Examining filesystem...
+1 (0): /mnt/nfs/a/b/c/d/e/f/g/h/i/j
+/mnt/nfs/a/b/c/d/e/f/g/h/i/j
+/mnt/nfs/a/b/c/d/e/f/g/h/i: Operation not permitted
+1 (0): /mnt/nfs/a/b/c/d/e/f/g/h
+/mnt/nfs/a/b/c/d/e/f/g/h
+Filled part #1: size = 0, 2 file(s), errno = 0
+2 (0): /mnt/nfs/a/b/c/d/e/f/g
+/mnt/nfs/a/b/c/d/e/f/g
+/mnt/nfs/a/b/c/d/e/f: Operation not permitted
+2 (0): /mnt/nfs/a/b/c/d/e
+/mnt/nfs/a/b/c/d/e
+Filled part #2: size = 0, 2 file(s), errno = 0
+3 (28): /mnt/nfs/a/b/c/d
+/mnt/nfs/a/b/c/d
+/mnt/nfs/a/b/c: Operation not permitted
+3 (0): /mnt/nfs/a/b
+/mnt/nfs/a/b
+Filled part #3: size = 28, 2 file(s), errno = 0
+/mnt/nfs/a/amir/subdir: Operation not permitted
+4 (10650): /mnt/nfs/a/amir/dir
+/mnt/nfs/a/amir/dir
+4 (0): /mnt/nfs/a/amir
+/mnt/nfs/a/amir
+Filled part #4: size = 10650, 2 file(s), errno = 0
+5 (12): /mnt/nfs/a
+/mnt/nfs/a
+Filled part #5: size = 12, 1 file(s)
+9 file(s) found.
+
+

--- a/readdir_error_tests.txt
+++ b/readdir_error_tests.txt
@@ -136,7 +136,7 @@ Filled part #10: size = 12, 1 file(s)
 
 
 ==============================
-amir73il-readdir_error branch (including all your code changes):
+amir73il-readdir_error branch (commit 5966ab6c19e5):
 ==============================
 
 --------------------
@@ -192,29 +192,44 @@ Errors injection at odd #readdir:
 missed subtrees (e.g. a/b/c) will be synced with recursive rsync.
 
 --------------------
-sudo ./fanotify_example /mnt/nfs/ 6
+sudo ./fanotify_example /mnt/nfs/ 5
 
 
-$ ./src/fpart -L -E -zz -Z -f 2 -vv /mnt/nfs/a
+$ ./src/fpart -L -E -zz -Z -f 2 -vvv /mnt/nfs/a
+
 Examining filesystem...
+init_file_entries(/mnt/nfs/a): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/b): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/b/c): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/b/c): fts_info=4, fts_errno=1
 /mnt/nfs/a/b/c: Operation not permitted
-1 (0): /mnt/nfs/a/b/c
 /mnt/nfs/a/b/c
 Filled part #1: size = 0, 1 file(s), errno = 1
-2 (0): /mnt/nfs/a/b
+1 (0): /mnt/nfs/a/b/c
+init_file_entries(/mnt/nfs/a/b): fts_info=6, fts_errno=0
 /mnt/nfs/a/b
-2 (0): /mnt/nfs/a/amir/subdir
+init_file_entries(/mnt/nfs/a/amir): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/subdir): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/subdir/foo): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/subdir): fts_info=6, fts_errno=0
 /mnt/nfs/a/amir/subdir
 Filled part #2: size = 0, 2 file(s), errno = 0
+2 (0): /mnt/nfs/a/b
+2 (0): /mnt/nfs/a/amir/subdir
+init_file_entries(/mnt/nfs/a/amir/dir): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/dir): fts_info=4, fts_errno=1
 /mnt/nfs/a/amir/dir: Operation not permitted
-3 (0): /mnt/nfs/a/amir/dir
 /mnt/nfs/a/amir/dir
 Filled part #3: size = 0, 1 file(s), errno = 1
-4 (0): /mnt/nfs/a/amir
+3 (0): /mnt/nfs/a/amir/dir
+init_file_entries(/mnt/nfs/a/amir): fts_info=6, fts_errno=0
 /mnt/nfs/a/amir
-4 (12): /mnt/nfs/a
+init_file_entries(/mnt/nfs/a/file): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a): fts_info=6, fts_errno=0
 /mnt/nfs/a
 Filled part #4: size = 12, 2 file(s), errno = 0
+4 (0): /mnt/nfs/a/amir
+4 (12): /mnt/nfs/a
 6 file(s) found.
 
 
@@ -222,42 +237,102 @@ Filled part #4: size = 12, 2 file(s), errno = 0
 Errors injection at even #readdir:
 ----------------------------------
 
-9 dirs in 5 parts, because dirs with errors are not packed.
-All subdirs have been observed because error is never on first readdir,
-but 4 dirs will not be synced.
+13 dirs in 10 parts, because of separate parts
+All subdirs observed because error is never on first readdir
 
 --------------------
 sudo ./fanotify_example /mnt/nfs/ 6
 
 $ ./src/fpart -L -E -zz -Z -f 2 -vv /mnt/nfs/a
+
 Examining filesystem...
-1 (0): /mnt/nfs/a/b/c/d/e/f/g/h/i/j
+init_file_entries(/mnt/nfs/a): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/b): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/b/c): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/b/c/d): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/b/c/d/e): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/b/c/d/e/f): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/b/c/d/e/f/g): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/b/c/d/e/f/g/h): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/b/c/d/e/f/g/h/i): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/b/c/d/e/f/g/h/i/j): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/b/c/d/e/f/g/h/i/j/foo): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/b/c/d/e/f/g/h/i/j): fts_info=6, fts_errno=0
 /mnt/nfs/a/b/c/d/e/f/g/h/i/j
+init_file_entries(/mnt/nfs/a/b/c/d/e/f/g/h/i): fts_info=7, fts_errno=1
 /mnt/nfs/a/b/c/d/e/f/g/h/i: Operation not permitted
-1 (0): /mnt/nfs/a/b/c/d/e/f/g/h
+/mnt/nfs/a/b/c/d/e/f/g/h/i: Operation not permitted
+Filled part #1: size = 0, 1 file(s), errno = 0
+1 (0): /mnt/nfs/a/b/c/d/e/f/g/h/i/j
+/mnt/nfs/a/b/c/d/e/f/g/h/i
+Filled part #2: size = 0, 1 file(s), errno = 1
+2 (0): /mnt/nfs/a/b/c/d/e/f/g/h/i
+init_file_entries(/mnt/nfs/a/b/c/d/e/f/g/h): fts_info=6, fts_errno=0
 /mnt/nfs/a/b/c/d/e/f/g/h
-Filled part #1: size = 0, 2 file(s), errno = 0
-2 (0): /mnt/nfs/a/b/c/d/e/f/g
+init_file_entries(/mnt/nfs/a/b/c/d/e/f/g): fts_info=6, fts_errno=0
 /mnt/nfs/a/b/c/d/e/f/g
+Filled part #3: size = 0, 2 file(s), errno = 0
+3 (0): /mnt/nfs/a/b/c/d/e/f/g/h
+3 (0): /mnt/nfs/a/b/c/d/e/f/g
+init_file_entries(/mnt/nfs/a/b/c/d/e/f): fts_info=7, fts_errno=1
 /mnt/nfs/a/b/c/d/e/f: Operation not permitted
-2 (0): /mnt/nfs/a/b/c/d/e
+/mnt/nfs/a/b/c/d/e/f: Operation not permitted
+/mnt/nfs/a/b/c/d/e/f
+Filled part #4: size = 0, 1 file(s), errno = 1
+4 (0): /mnt/nfs/a/b/c/d/e/f
+init_file_entries(/mnt/nfs/a/b/c/d/e): fts_info=6, fts_errno=0
 /mnt/nfs/a/b/c/d/e
-Filled part #2: size = 0, 2 file(s), errno = 0
-3 (28): /mnt/nfs/a/b/c/d
+init_file_entries(/mnt/nfs/a/b/c/d/bar): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/b/c/d/file): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/b/c/d/foo): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/b/c/d): fts_info=6, fts_errno=0
 /mnt/nfs/a/b/c/d
+Filled part #5: size = 28, 2 file(s), errno = 0
+5 (0): /mnt/nfs/a/b/c/d/e
+5 (28): /mnt/nfs/a/b/c/d
+init_file_entries(/mnt/nfs/a/b/c): fts_info=7, fts_errno=1
 /mnt/nfs/a/b/c: Operation not permitted
-3 (0): /mnt/nfs/a/b
+/mnt/nfs/a/b/c: Operation not permitted
+/mnt/nfs/a/b/c
+Filled part #6: size = 0, 1 file(s), errno = 1
+6 (0): /mnt/nfs/a/b/c
+init_file_entries(/mnt/nfs/a/b): fts_info=6, fts_errno=0
 /mnt/nfs/a/b
-Filled part #3: size = 28, 2 file(s), errno = 0
+init_file_entries(/mnt/nfs/a/amir): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/subdir): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/subdir/foo): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/subdir): fts_info=7, fts_errno=1
 /mnt/nfs/a/amir/subdir: Operation not permitted
-4 (10650): /mnt/nfs/a/amir/dir
+/mnt/nfs/a/amir/subdir: Operation not permitted
+Filled part #7: size = 0, 1 file(s), errno = 0
+7 (0): /mnt/nfs/a/b
+/mnt/nfs/a/amir/subdir
+Filled part #8: size = 0, 1 file(s), errno = 1
+8 (0): /mnt/nfs/a/amir/subdir
+init_file_entries(/mnt/nfs/a/amir/dir): fts_info=1, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/dir/f10): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/dir/f11): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/dir/f12): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/dir/f13): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/dir/f14): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/dir/f15): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/dir/f16): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/dir/f17): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/dir/f18): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/dir/f19): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/dir/md5sum.out): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/dir/file): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/dir/file2): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a/amir/dir): fts_info=6, fts_errno=0
 /mnt/nfs/a/amir/dir
-4 (0): /mnt/nfs/a/amir
+init_file_entries(/mnt/nfs/a/amir): fts_info=6, fts_errno=0
 /mnt/nfs/a/amir
-Filled part #4: size = 10650, 2 file(s), errno = 0
-5 (12): /mnt/nfs/a
+Filled part #9: size = 10650, 2 file(s), errno = 0
+9 (10650): /mnt/nfs/a/amir/dir
+9 (0): /mnt/nfs/a/amir
+init_file_entries(/mnt/nfs/a/file): fts_info=8, fts_errno=0
+init_file_entries(/mnt/nfs/a): fts_info=6, fts_errno=0
 /mnt/nfs/a
-Filled part #5: size = 12, 1 file(s)
-9 file(s) found.
-
-
+Filled part #10: size = 12, 1 file(s)
+10 (12): /mnt/nfs/a
+13 file(s) found.

--- a/src/file_entry.c
+++ b/src/file_entry.c
@@ -645,6 +645,10 @@ init_file_entries(char *file_path, struct file_entry **head, fnum_t *count,
     fsize_t curdir_size = 0;            /* current dir size */
 
     while((p = fts_read(ftsp)) != NULL) {
+        if(options->verbose >= OPT_VVVERBOSE) {
+            fprintf(stderr, "%s(%s): fts_info=%d, ftp_errno=%d\n", __func__,
+                p->fts_path, p->fts_info, p->fts_errno);
+        }
         switch (p->fts_info) {
             /* misc errors */
             case FTS_ERR:

--- a/src/fpart.c
+++ b/src/fpart.c
@@ -580,6 +580,7 @@ handle_options(struct program_options *options, int *argcp, char ***argvp)
         }
         if (options->max_size == 0)
             options->max_size = INTMAX_MAX;
+    }
 
     /* option -S (needs '-L' and '-s') */
     if((options->skip_big == OPT_SKIPBIG) &&

--- a/src/fts.c
+++ b/src/fts.c
@@ -963,7 +963,8 @@ mem1:				saved_errno = errno;
 
 	/* If didn't find anything, return NULL. */
 	if (!nitems) {
-		if (type == BREAD)
+		if (type == BREAD &&
+			cur->fts_info != FTS_DNR && cur->fts_info != FTS_ERR)
 			cur->fts_info = FTS_DP;
 		return (NULL);
 	}

--- a/src/options.c
+++ b/src/options.c
@@ -95,6 +95,7 @@ init_options(struct program_options *options)
     options->nexclude_files_ci = 0;
     options->dirs_include = DFLT_OPT_DIRSINCLUDE;
     options->dir_depth = DFLT_OPT_DIR_DEPTH;
+    options->dnr_negative_size = 0;
     options->leaf_dirs = DFLT_OPT_LEAFDIRS;
     options->dirs_only = DFLT_OPT_DIRSONLY;
     options->live_mode = DFLT_OPT_LIVEMODE;

--- a/src/options.h
+++ b/src/options.h
@@ -69,6 +69,7 @@ struct program_options {
 #define OPT_NOVERBOSE               0
 #define OPT_VERBOSE                 1
 #define OPT_VVERBOSE                2
+#define OPT_VVVERBOSE               3
 #define DFLT_OPT_VERBOSE            OPT_NOVERBOSE
     unsigned char verbose;
 /* follow symbolic links (option -l) */

--- a/src/options.h
+++ b/src/options.h
@@ -101,6 +101,8 @@ struct program_options {
 #define OPT_ALLDIRS                 3   /* include all directories */
 #define DFLT_OPT_DIRSINCLUDE        OPT_NOEMPTYDIRS
     unsigned char dirs_include;
+/* reported negative part size for un-readable directories (option -Z) */
+    unsigned char dnr_negative_size;
 /* display directories after certain depth (option -d) */
 #define OPT_NODIRDEPTH              -1
 #define DFLT_OPT_DIR_DEPTH          OPT_NODIRDEPTH

--- a/src/utils.c
+++ b/src/utils.c
@@ -345,7 +345,7 @@ str_is_negative(const char *str)
 
 /* Convert a str to a uintmax > 0
    - support human-friendly multipliers
-   - only accept values > 0 as input
+   - only accept values > 0 and < INTMAX_MAX as input
    - return 0 if an error occurs */
 uintmax_t
 str_to_uintmax(const char *str, const unsigned char handle_multiplier)
@@ -392,6 +392,9 @@ str_to_uintmax(const char *str, const unsigned char handle_multiplier)
             return (0);
         }
     }
+    /* Negative intmax_t values are reserved for error reporting */
+    if(val > INTMAX_MAX)
+        return (0);
 #if defined(DEBUG)
     fprintf(stderr, "%s(): converted string %s to value %ju\n", __func__,
         optarg, val);

--- a/src/utils.c
+++ b/src/utils.c
@@ -162,6 +162,10 @@ get_size(char *file_path, struct stat *file_stat,
     }
 
     while((p = fts_read(ftsp)) != NULL) {
+        if(options->verbose >= OPT_VVVERBOSE) {
+            fprintf(stderr, "%s(%s): fts_info=%d, ftp_errno=%d\n", __func__,
+                p->fts_path, p->fts_info, p->fts_errno);
+        }
         switch (p->fts_info) {
             case FTS_ERR:   /* misc error */
             case FTS_DNR:   /* un-readable directory */
@@ -184,10 +188,10 @@ get_size(char *file_path, struct stat *file_stat,
                    already been made before */
                 if((!valid_file(p, options, VF_EXCLUDEONLY)) &&
                     (p->fts_level > 0)) {
-#if defined(DEBUG)
-                    fprintf(stderr, "%s(): skipping directory: %s\n", __func__,
-                        p->fts_path);
-#endif
+                    if(options->verbose >= OPT_VVVERBOSE) {
+                        fprintf(stderr, "%s(): skipping directory: %s\n", __func__,
+                            p->fts_path);
+                    }
                     fts_set(ftsp, p, FTS_SKIP);
                 }
                 continue;
@@ -198,10 +202,10 @@ get_size(char *file_path, struct stat *file_stat,
 
                 /* Excluded files do not account for returned size */
                 if(!valid_file(p, options, VF_EXCLUDEONLY)) {
-#if defined(DEBUG)
-                    fprintf(stderr, "%s(): skipping file: %s\n", __func__,
-                        p->fts_path);
-#endif
+                    if(options->verbose >= OPT_VVVERBOSE) {
+                        fprintf(stderr, "%s(): skipping file: %s\n", __func__,
+                            p->fts_path);
+                    }
                 }
                 else
                     file_size += p->fts_statp->st_size;

--- a/tools/fpsync
+++ b/tools/fpsync
@@ -319,8 +319,14 @@ tool_get_fpart_mode_opts () {
 tool_init_fpart_job_command () {
     case "$1" in
     "rsync")
-        FPART_JOBCOMMAND="/bin/sh -c '${SUDO} ${TOOL_BIN} ${OPT_TOOL} \
-            ${TOOL_MODEOPTS} --files-from=\\\"\${FPART_PARTFILENAME}\\\" --from0 \
+        # MODEOPTS is set per partition according to $FPART_PARTSIZE
+        # When $FPART_PARTSIZE is negative, we force recursive rsync
+        # because fpart was not able to list sub-directories
+        FPART_JOBCOMMAND="/bin/sh -c 'MODEOPTS=\\\"${TOOL_MODEOPTS}\\\"; \
+            [ \\\"\${FPART_PARTSIZE}\\\" -lt 0 ] && \
+	        MODEOPTS=\\\"${TOOL_MODEOPTS_R}\\\"; \
+            ${SUDO} ${TOOL_BIN} ${OPT_TOOL} \\\${MODEOPTS} \
+            --files-from=\\\"\${FPART_PARTFILENAME}\\\" --from0 \
             \\\"${OPT_SRCDIR}/\\\" \
             \\\"${OPT_DSTURL}/\\\"' \
             1>\"${FPART_LOGDIR}/\${FPART_PARTNUMBER}.stdout\" \
@@ -1004,6 +1010,7 @@ FPART_LOGFILE="${FPART_LOGDIR}/fpart.log"
 
 # Prepare mode-specific tool and fpart options
 TOOL_MODEOPTS=$(tool_get_tool_mode_opts "${OPT_TOOL_NAME}" "${OPT_DIRSONLY}")
+TOOL_MODEOPTS_R=$(tool_get_tool_mode_opts "${OPT_TOOL_NAME}" "")
 FPART_MODEOPTS=$(tool_get_fpart_mode_opts "${OPT_TOOL_NAME}" "${OPT_DIRSONLY}")
 FPART_JOBCOMMAND= ; tool_init_fpart_job_command "${OPT_TOOL_NAME}"
 FPART_POSTHOOK="echo \"${FPART_JOBCOMMAND}\" > \


### PR DESCRIPTION
This work was done to tackle real world issues encountered with fpsync of large data sets from commercial SMB file servers.

readdir() errors used to be rare in filesystems, which may explain how the FTS bug still exists in distros today.
One of the reasons to start seeing readdir() errors recently on Linux SMB client is the addition of support for
compound SMB requests added in recent Linux kernels.

That support defers the opendir() request to the server until the first readdir() call and opendir() on the server is prone to ENFILE/EMFILE temporary errors, which get reflected as EBADF to the readdir() caller.