### PR TITLE
fpsync: start all idle workers before refresh

### DIFF
--- a/tools/fpsync
+++ b/tools/fpsync
@@ -939,9 +939,10 @@ job_queue_loop () {
                     work_list_push "$!:${_NEXT}:${_NEXT_HOST}"
                 fi
             fi
+        else
+            work_list_refresh
+            sleep 0.2
         fi
-        work_list_refresh
-        sleep 0.2
     done
 
     if [ "${_NEXT}" = "fp_done" ]


### PR DESCRIPTION
There is no reason to call work_list_refresh after every job start;
only call it on loop iterations when more idle workers are needed.